### PR TITLE
net-fs/cifs-utils: Fix krb5 support

### DIFF
--- a/net-fs/cifs-utils/cifs-utils-6.4.ebuild
+++ b/net-fs/cifs-utils/cifs-utils-6.4.ebuild
@@ -81,6 +81,8 @@ src_install() {
 		dodir /etc/request-key.d
 		echo 'create dns_resolver * * /usr/sbin/cifs.upcall %k' \
 			> "${ED}/etc/request-key.d/cifs.upcall.conf"
+		echo 'create cifs.spnego * * /usr/sbin/cifs.upcall %k' \
+			> "${ED}/etc/request-key.d/cifs.spnego.conf"
 	fi
 }
 

--- a/net-fs/cifs-utils/cifs-utils-6.5.ebuild
+++ b/net-fs/cifs-utils/cifs-utils-6.5.ebuild
@@ -81,6 +81,8 @@ src_install() {
 		dodir /etc/request-key.d
 		echo 'create dns_resolver * * /usr/sbin/cifs.upcall %k' \
 			> "${ED}/etc/request-key.d/cifs.upcall.conf"
+		echo 'create cifs.spnego * * /usr/sbin/cifs.upcall %k' \
+			> "${ED}/etc/request-key.d/cifs.spnego.conf"
 	fi
 }
 

--- a/net-fs/cifs-utils/cifs-utils-6.6.ebuild
+++ b/net-fs/cifs-utils/cifs-utils-6.6.ebuild
@@ -81,6 +81,8 @@ src_install() {
 		dodir /etc/request-key.d
 		echo 'create dns_resolver * * /usr/sbin/cifs.upcall %k' \
 			> "${ED}/etc/request-key.d/cifs.upcall.conf"
+		echo 'create cifs.spnego * * /usr/sbin/cifs.upcall %k' \
+			> "${ED}/etc/request-key.d/cifs.spnego.conf"
 	fi
 }
 


### PR DESCRIPTION
- Cifs mounts with sec=krb5 are now working
  - Official documentation:
    https://www.samba.org/samba/docs/man/manpages-3/cifs.upcall.8.html
